### PR TITLE
fix: namespace on sample code

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -76,7 +76,7 @@ public static MauiApp CreateMauiApp()
 <ContentPage 
 	xmlns="http://xamarin.com/schemas/2014/forms" 
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
-	xmlns:sv="clr-namespace:AiForms.Renderers;assembly=SettingsView"
+	xmlns:sv="clr-namespace:AiForms.Settings;assembly=SettingsView"
 	x:Class="Sample.Views.SettingsViewPage">
     
 <sv:SettingsView HasUnevenRows="true">
@@ -113,7 +113,7 @@ SettingsViewのプロパティ設定はApp.xamlに記述した方が良いかも
 ```xml
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:sv="clr-namespace:AiForms.Renderers;assembly=SettingsView"
+             xmlns:sv="clr-namespace:AiForms.Settings;assembly=SettingsView"
              x:Class="Sample.App">
     <Application.Resources>
         <ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ public static MauiApp CreateMauiApp()
 <ContentPage 
 	xmlns="http://xamarin.com/schemas/2014/forms" 
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
-	xmlns:sv="clr-namespace:AiForms.Renderers;assembly=SettingsView"
+	xmlns:sv="clr-namespace:AiForms.Settings;assembly=SettingsView"
 	x:Class="Sample.Views.SettingsViewPage">
     
 <sv:SettingsView HasUnevenRows="true">
@@ -113,7 +113,7 @@ For example...
 ```xml
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:sv="clr-namespace:AiForms.Renderers;assembly=SettingsView"
+             xmlns:sv="clr-namespace:AiForms.Settings;assembly=SettingsView"
              x:Class="Sample.App">
     <Application.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
In the sample code on the Readme, the SettingsView's namespace was incorrect.