### PR TITLE
fix: IMauiContext is null for formatted label

### DIFF
--- a/SettingsView/Native/iOS/CustomHeaderFooterView.cs
+++ b/SettingsView/Native/iOS/CustomHeaderFooterView.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.ComponentModel;
 using AiForms.Settings.Extensions;
 using CoreGraphics;
@@ -71,7 +72,7 @@ public class CustomHeaderFooterView:UITableViewHeaderFooterView
     NSLayoutConstraint _heightConstraint;
     View _virtualCell;
     UITableView _tableView;
-    IMauiContext _mauiContext => _virtualCell.FindMauiContext();    
+    IMauiContext? _mauiContext => _virtualCell.FindMauiContext();    
 
     public CustomHeaderFooterView()
     {
@@ -210,7 +211,12 @@ public class CustomHeaderFooterView:UITableViewHeaderFooterView
         {
             // If Handler is not generated, generate it.            
             handler = GetNewHandler();
-        }        
+        }
+
+        if (_mauiContext == null)
+        {
+            return;
+        }
 
         var viewHandlerType = _mauiContext.Handlers.GetHandlerType(_virtualCell.GetType());
         var reflectableType = handler as System.Reflection.IReflectableType;
@@ -276,14 +282,21 @@ public class CustomHeaderFooterView:UITableViewHeaderFooterView
         LayoutDispatcher();
     }
 
-    protected virtual IPlatformViewHandler GetNewHandler()
+    protected virtual IPlatformViewHandler? GetNewHandler()
     {
         if(_virtualCell == null)
         {
-            throw new InvalidOperationException("Hearder or Footer must have a view");
+            throw new InvalidOperationException("Header or Footer must have a view");
         }
 
-        var newHandler = _virtualCell.ToHandler(_virtualCell.FindMauiContext());
+        var findMauiContext = _virtualCell.FindMauiContext();
+
+        if (findMauiContext == null)
+        {
+            return null;
+        }
+
+        var newHandler = _virtualCell.ToHandler(findMauiContext);
 
         ArrangeSubView(newHandler);
 


### PR DESCRIPTION
This fixes an issue with the `CustomHeaderFooterView` where the `_mauiContext` is sometimes `null` and crashing my application with the following.

```
System.ArgumentNullException: Value cannot be null. (Parameter 'context')
   at Microsoft.Maui.Platform.ElementExtensions.ToHandler(IElement view, IMauiContext context)
   at Microsoft.Maui.Platform.ViewExtensions.ToHandler(IView view, IMauiContext context)
   at AiForms.Settings.Platforms.iOS.CustomHeaderFooterView.GetNewHandler() in /mauk/AiForms.Maui.SettingsView/SettingsView/Native/iOS/CustomHeaderFooterView.cs:line 286
```

I was able to debug these changes locally and verified after this change, my application does not crash.

If you need further evidence, or would like this done differently please let me know!

**Note:** I only enabled nullability on this file to return `IMauiContext?` if this is not the approach you'd like let me know and I will take it off.