### PR TITLE
Remove references to 'TableView' as it is marked obsolete #50

### DIFF
--- a/SettingsView/Native/iOS/Cells/CellBaseView.cs
+++ b/SettingsView/Native/iOS/Cells/CellBaseView.cs
@@ -178,7 +178,7 @@ public class CellBaseView : UITableViewCell, IImageSourcePartSetter
         {
             UpdateSelectedColor();
         }
-        else if (e.PropertyName == TableView.RowHeightProperty.PropertyName)
+        else if (e.PropertyName == SettingsView.RowHeightProperty.PropertyName)
         {
             UpdateMinRowHeight();
         }

--- a/SettingsView/SettingsView.DefineProperites.cs
+++ b/SettingsView/SettingsView.DefineProperites.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using AiForms.Settings.Extensions;
+using Microsoft.Maui.Controls.Internals;
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows.Input;
-using Microsoft.Maui.Controls.Internals;
 
 namespace AiForms.Settings;
 
@@ -37,7 +38,7 @@ public partial class SettingsView
             Colors.Transparent,
             defaultBindingMode: BindingMode.OneWay
         );
-    
+
     /// <summary>
     /// A color of out of region and entire region. They contains header, footer and cell (in case android).
     /// </summary>
@@ -231,6 +232,50 @@ public partial class SettingsView
     }
 
     /// <summary>
+    /// The row height property.
+    /// </summary>
+    public static BindableProperty RowHeightProperty =
+        BindableProperty.Create(
+            nameof(RowHeight),
+            typeof(int),
+            typeof(SettingsView),
+            -1,
+            defaultBindingMode: BindingMode.OneWay
+        );
+
+    /// <summary>
+    /// The row height property.
+    /// </summary>
+    /// <value>Height of the table rows.</value>
+    public int RowHeight
+    {
+        get { return (int)GetValue(RowHeightProperty); }
+        set { SetValue(RowHeightProperty, value); }
+    }
+
+    /// <summary>
+    /// The has uneven rows property.
+    /// </summary>
+    public static BindableProperty HasUnevenRowsProperty =
+        BindableProperty.Create(
+            nameof(HasUnevenRows),
+            typeof(bool),
+            typeof(SettingsView),
+            false,
+            defaultBindingMode: BindingMode.OneWay
+        );
+
+    /// <summary>
+    /// The has uneven rows property.
+    /// </summary>
+    /// <value>If rows are uneven height.</value>
+    public bool HasUnevenRows
+    {
+        get { return (bool)GetValue(HasUnevenRowsProperty); }
+        set { SetValue(HasUnevenRowsProperty, value); }
+    }
+
+    /// <summary>
     /// The header height property.
     /// </summary>
     public static BindableProperty HeaderHeightProperty =
@@ -400,7 +445,7 @@ public partial class SettingsView
             typeof(SettingsView),
             -1.0,
             defaultBindingMode: BindingMode.OneWay,
-            defaultValueCreator: bindable => Device.GetNamedSize(NamedSize.Default, (SettingsView)bindable)
+            defaultValueCreator: bindable => (bindable as Element)?.FindMauiContext()?.Services?.GetService<IFontManager>()?.DefaultFontSize ?? 0d
         );
 
     /// <summary>
@@ -747,7 +792,7 @@ public partial class SettingsView
         set { SetValue(CellHintFontAttributesProperty, value); }
     }
 
-    //Only Android 
+    //Only Android
     /// <summary>
     /// The use description as value property.
     /// </summary>
@@ -959,7 +1004,7 @@ public partial class SettingsView
 
         IList oldValueAsEnumerable;
         IList newValueAsEnumerable;
-        try 
+        try
         {
             oldValueAsEnumerable = oldValue as IList;
             newValueAsEnumerable = newValue as IList;

--- a/SettingsView/SettingsView.cs
+++ b/SettingsView/SettingsView.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Specialized;
-using System.Linq;
+﻿using System.Collections.Specialized;
 using System.ComponentModel;
-using Microsoft.Maui.Controls.Internals;
 
 namespace AiForms.Settings;
 
@@ -10,7 +7,7 @@ namespace AiForms.Settings;
 /// Settings view.
 /// </summary>
 [ContentProperty("Root")]
-public partial class SettingsView : TableView
+public partial class SettingsView : View
 {
     internal static Action _clearCache;
     /// <summary>
@@ -25,11 +22,11 @@ public partial class SettingsView : TableView
     /// Gets or sets the model.
     /// </summary>
     /// <value>The model.</value>
-    public new SettingsModel Model { get; set; }
+    public SettingsModel Model { get; set; }
     /// <summary>
     /// Occurs when model changed.
     /// </summary>
-    public new event EventHandler ModelChanged;
+    public event EventHandler ModelChanged;
     /// <summary>
     /// Occurs when collection changed.
     /// </summary>
@@ -62,7 +59,7 @@ public partial class SettingsView : TableView
     /// Gets or sets the root.
     /// </summary>
     /// <value>The root.</value>
-    public new SettingsRoot Root
+    public SettingsRoot Root
     {
         get { return _root; }
         set {
@@ -164,7 +161,7 @@ public partial class SettingsView : TableView
                         cell.BindingContext = context; // so set the original bindingcontext again.
                     }
                 }
-            }            
+            }
         }
         CollectionChanged?.Invoke(sender, e);
     }
@@ -181,12 +178,12 @@ public partial class SettingsView : TableView
             foreach(var cell in e.NewItems.Cast<CellBase>())
             {
                 cell.Parent = this;
-            }            
+            }
         }
         SectionCollectionChanged?.Invoke(sender, e);
     }
 
-    new void OnModelChanged()
+    void OnModelChanged()
     {
         if(Root == null)
         {
@@ -227,7 +224,4 @@ public partial class SettingsView : TableView
             ModelChanged(this, EventArgs.Empty);
 
     }
-
-    //make the unnecessary property existing at TableView sealed.
-    private new int Intent { get; set; }
 }


### PR DESCRIPTION
### Removed references to `TableView`

- Added bindable properties that were inherited from `TableView`
- Removed `new` keyword as hiding `TableView` members no longer required

Fixes #50