### PR TITLE
Fix android dispose crash in AiRecyclerView

### DIFF
--- a/SettingsView/Native/Android/AiRecyclerView.cs
+++ b/SettingsView/Native/Android/AiRecyclerView.cs
@@ -86,6 +86,24 @@ public class AiRecyclerView : RecyclerView
 
         if (disposing)
         {
+            // ステップ1: RecyclerViewからコンポーネントを切り離す
+            // これにより以降のDispose中にRecyclerView経由のコールバックを防止する
+            try { SetAdapter(null); }
+            catch (ObjectDisposedException) { }
+
+            try { SetLayoutManager(null); }
+            catch (ObjectDisposedException) { }
+
+            if (_itemDecoration != null)
+            {
+                try { RemoveItemDecoration(_itemDecoration); }
+                catch (ObjectDisposedException) { }
+            }
+
+            try { _itemTouchhelper?.AttachToRecyclerView(null); }
+            catch (ObjectDisposedException) { }
+
+            // ステップ2: HeaderView/FooterViewをクリーンアップ
             if (_settingsView?.Root != null)
             {
                 foreach (var section in _settingsView.Root)
@@ -101,6 +119,7 @@ public class AiRecyclerView : RecyclerView
                 }
             }
 
+            // ステップ3: 保留中のhandlerを破棄
             if (_shouldDisposeHandlers != null)
             {
                 foreach (var handler in _shouldDisposeHandlers)
@@ -115,17 +134,20 @@ public class AiRecyclerView : RecyclerView
             }
             _shouldDisposeHandlers = null;
 
-            if (_itemDecoration != null)
-            {
-                RemoveItemDecoration(_itemDecoration);
-            }
-
+            // ステップ4: イベント購読を解除
             if (_parentPage != null)
             {
                 _parentPage.Appearing -= ParentPageAppearing;
                 _parentPage = null;
             }
 
+            if (_settingsView != null)
+            {
+                _settingsView.Root.CollectionChanged -= RootCollectionChanged;
+                _settingsView = null;
+            }
+
+            // ステップ5: 切り離し済みのコンポーネントをDispose
             _adapter?.Dispose();
             _adapter = null;
             _layoutManager?.Dispose();
@@ -139,12 +161,6 @@ public class AiRecyclerView : RecyclerView
             _itemDecoration = null;
             _divider?.Dispose();
             _divider = null;
-
-            if (_settingsView != null)
-            {
-                _settingsView.Root.CollectionChanged -= RootCollectionChanged;
-                _settingsView = null;
-            }
         }
         base.Dispose(disposing);
     }
@@ -164,6 +180,8 @@ public class AiRecyclerView : RecyclerView
 
     void RootCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
+        if (_disposed) return;
+
         if (e.OldItems == null)
         {
             return;

--- a/SettingsView/Native/Android/ModelProxy.cs
+++ b/SettingsView/Native/Android/ModelProxy.cs
@@ -25,6 +25,7 @@ public class ModelProxy:List<RowInfo>,IDisposable
     SettingsRoot _root;
     SettingsViewRecyclerAdapter _adapter;
     RecyclerView _recyclerView;
+    bool _disposed;
 
     public ModelProxy(SettingsView settingsView,SettingsViewRecyclerAdapter adapter,RecyclerView recyclerView)
     {
@@ -37,12 +38,18 @@ public class ModelProxy:List<RowInfo>,IDisposable
         _root.CollectionChanged += OnRootCollectionChanged;
 
         FillProxy();
-    }       
+    }
 
     public void Dispose()
     {
-        _root.SectionCollectionChanged -= OnRootSectionCollectionChanged;
-        _root.CollectionChanged -= OnRootCollectionChanged;
+        if (_disposed) return;
+        _disposed = true;
+
+        if (_root != null)
+        {
+            _root.SectionCollectionChanged -= OnRootSectionCollectionChanged;
+            _root.CollectionChanged -= OnRootCollectionChanged;
+        }
         _model = null;
         _root = null;
         _adapter = null;
@@ -54,6 +61,8 @@ public class ModelProxy:List<RowInfo>,IDisposable
 
     void OnRootCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
+        if (_disposed) return;
+
         switch(e.Action)
         {
             case NotifyCollectionChangedAction.Add:
@@ -82,6 +91,8 @@ public class ModelProxy:List<RowInfo>,IDisposable
 
     void OnRootSectionCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
+        if (_disposed) return;
+
         switch(e.Action)
         {
             case NotifyCollectionChangedAction.Add:

--- a/SettingsView/Native/Android/SettingsViewLayoutManager.cs
+++ b/SettingsView/Native/Android/SettingsViewLayoutManager.cs
@@ -11,15 +11,18 @@ public class SettingsViewLayoutManager:LinearLayoutManager
     SettingsView _settingsView;
     Android.Content.Context _context;
     Dictionary<Android.Views.View, int> ItemHeights = new Dictionary<Android.Views.View, int>();
+    bool _disposed;
 
     public SettingsViewLayoutManager(Android.Content.Context context,SettingsView settingsView):base(context)
     {
         _context = context;
         _settingsView = settingsView;
-    }        
+    }
 
     public override int GetDecoratedMeasuredHeight(Android.Views.View child)
     {
+        if (_disposed) return 0;
+
         var height =  base.GetDecoratedMeasuredHeight(child);
         ItemHeights[child] = height;
         return height;
@@ -27,9 +30,12 @@ public class SettingsViewLayoutManager:LinearLayoutManager
 
     protected override void Dispose(bool disposing)
     {
+        if (_disposed) return;
+        _disposed = true;
+
         if(disposing)
         {
-            ItemHeights.Clear();
+            ItemHeights?.Clear();
             ItemHeights = null;
             _context = null;
             _settingsView = null;
@@ -41,8 +47,13 @@ public class SettingsViewLayoutManager:LinearLayoutManager
     {
         base.OnLayoutCompleted(state);
 
+        if (_disposed || _settingsView == null || _context == null || ItemHeights == null)
+        {
+            return;
+        }
+
         var total = ItemHeights.Sum(x => x.Value);
 
-        _settingsView.VisibleContentHeight = _context.FromPixels(total);              
+        _settingsView.VisibleContentHeight = _context.FromPixels(total);
     }
 }

--- a/SettingsView/Native/Android/SettingsViewRecyclerAdapter.cs
+++ b/SettingsView/Native/Android/SettingsViewRecyclerAdapter.cs
@@ -30,6 +30,7 @@ public class SettingsViewRecyclerAdapter:RecyclerView.Adapter,AView.IOnClickList
     SettingsView _settingsView;
     RecyclerView _recyclerView;
     ModelProxy _proxy;
+    bool _disposed;
 
     List<ViewHolder> _viewHolders = new List<ViewHolder>();
     protected Lazy<IFontManager> _fontManager;
@@ -59,6 +60,7 @@ public class SettingsViewRecyclerAdapter:RecyclerView.Adapter,AView.IOnClickList
 
     void _settingsView_ModelChanged(object sender, EventArgs e)
     {
+        if (_disposed) return;
         if (_recyclerView != null)
         {
             _proxy.FillProxy();
@@ -68,6 +70,7 @@ public class SettingsViewRecyclerAdapter:RecyclerView.Adapter,AView.IOnClickList
 
     void OnSectionPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
+        if (_disposed) return;
         if (e.PropertyName == Section.IsVisibleProperty.PropertyName)
         {
             UpdateSectionVisible((Section)sender);
@@ -88,6 +91,7 @@ public class SettingsViewRecyclerAdapter:RecyclerView.Adapter,AView.IOnClickList
 
     void OnCellPropertyChanged(object sender, CellPropertyChangedEventArgs e)
     {
+        if (_disposed) return;
         if(e.PropertyName == CellBase.IsVisibleProperty.PropertyName)
         {
             UpdateCellVisible(e.Section, (CellBase)sender);
@@ -127,7 +131,7 @@ public class SettingsViewRecyclerAdapter:RecyclerView.Adapter,AView.IOnClickList
     /// Gets the item count.
     /// </summary>
     /// <value>The item count.</value>
-    public override int ItemCount => _proxy.Count;
+    public override int ItemCount => _proxy?.Count ?? 0;
 
     /// <summary>
     /// return ID (As in paticular it doesn't exist, return the position.)
@@ -320,20 +324,29 @@ public class SettingsViewRecyclerAdapter:RecyclerView.Adapter,AView.IOnClickList
     /// <param name="disposing">If set to <c>true</c> disposing.</param>
     protected override void Dispose(bool disposing)
     {
+        if (_disposed) return;
+        _disposed = true;
+
         if(disposing){
-            _settingsView.ModelChanged -= _settingsView_ModelChanged;
-            _settingsView.SectionPropertyChanged -= OnSectionPropertyChanged;
-            _settingsView.CellPropertyChanged -= OnCellPropertyChanged;
+            if (_settingsView != null)
+            {
+                _settingsView.ModelChanged -= _settingsView_ModelChanged;
+                _settingsView.SectionPropertyChanged -= OnSectionPropertyChanged;
+                _settingsView.CellPropertyChanged -= OnCellPropertyChanged;
+            }
             _proxy?.Dispose();
             _proxy = null;
             _settingsView = null;
 
-            foreach (var holder in _viewHolders)
+            if (_viewHolders != null)
             {
-                holder.Dispose();
+                foreach (var holder in _viewHolders)
+                {
+                    holder.Dispose();
+                }
+                _viewHolders.Clear();
+                _viewHolders = null;
             }
-            _viewHolders.Clear();
-            _viewHolders = null;
         }
         base.Dispose(disposing);
     }


### PR DESCRIPTION
## Summary
- RecyclerView から adapter/layoutManager を Dispose 前に切り離す（`SetAdapter(null)`, `SetLayoutManager(null)`）ことで、破棄チェーン中のコールバック再突入によるクラッシュを防止
- `SettingsViewLayoutManager.OnLayoutCompleted()` に null チェックを追加（Dispose 後のコールバックでの NullReferenceException を防止）
- `SettingsViewRecyclerAdapter`, `ModelProxy` に `_disposed` フラグと null チェックを追加

## Test plan
- [ ] SettingsView を含むページから NavigationPage.PopAsync で戻る操作でクラッシュしないことを確認
- [ ] 素早いページ遷移の繰り返しでもクラッシュしないことを確認
- [ ] SettingsView の表示・操作が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)