### PR TITLE
Fix NRE in AiRecyclerView.Dispose for MAUI 9 auto-disconnect

### DIFF
--- a/SettingsView/Handlers/SettingsViewHandler.Android.cs
+++ b/SettingsView/Handlers/SettingsViewHandler.Android.cs
@@ -48,37 +48,37 @@ public partial class SettingsViewHandler : ViewHandler<SettingsView, AiRecyclerV
 
     private static void MapSeparatorColor(SettingsViewHandler handler, SettingsView sv)
     {
-        handler.PlatformView.UpdateSeparatorColor();
+        handler.PlatformView?.UpdateSeparatorColor();
     }
 
     private static void MapBackgroundColor(SettingsViewHandler handler, SettingsView sv)
     {
-        handler.PlatformView.UpdateBackgroundColor();
+        handler.PlatformView?.UpdateBackgroundColor();
     }
 
     private static void MapRowHeight(SettingsViewHandler handler, SettingsView sv)
     {
-        handler.PlatformView.UpdateRowHeight();
+        handler.PlatformView?.UpdateRowHeight();
     }
 
     private static void MapScrollToTop(SettingsViewHandler handler, SettingsView sv)
     {
-        handler.PlatformView.UpdateScrollToTop();
+        handler.PlatformView?.UpdateScrollToTop();
     }
 
     private static void MapScrollToBottom(SettingsViewHandler handler, SettingsView sv)
     {
-        handler.PlatformView.UpdateScrollToBottom();
+        handler.PlatformView?.UpdateScrollToBottom();
     }
 
     private static void MapDataSetChanged(SettingsViewHandler handler, SettingsView sv)
     {
-        handler.PlatformView.GetAdapter()?.NotifyDataSetChanged();
+        handler.PlatformView?.GetAdapter()?.NotifyDataSetChanged();
     }
 
     private static void MapInvalidateItemDecorations(SettingsViewHandler handler, SettingsView sv)
     {
-        handler.PlatformView.InvalidateItemDecorations();
+        handler.PlatformView?.InvalidateItemDecorations();
     }
 }
 

--- a/SettingsView/Native/Android/AiRecyclerView.cs
+++ b/SettingsView/Native/Android/AiRecyclerView.cs
@@ -64,7 +64,10 @@ public class AiRecyclerView : RecyclerView
         }
 
         _parentPage = elm as Page;
-        _parentPage.Appearing += ParentPageAppearing;
+        if (_parentPage != null)
+        {
+            _parentPage.Appearing += ParentPageAppearing;
+        }
     }
 
     public AiRecyclerView(Context context, IAttributeSet attrs) : base(context, attrs)
@@ -89,19 +92,19 @@ public class AiRecyclerView : RecyclerView
             // ステップ1: RecyclerViewからコンポーネントを切り離す
             // これにより以降のDispose中にRecyclerView経由のコールバックを防止する
             try { SetAdapter(null); }
-            catch (ObjectDisposedException) { }
+            catch (Exception) { }
 
             try { SetLayoutManager(null); }
-            catch (ObjectDisposedException) { }
+            catch (Exception) { }
 
             if (_itemDecoration != null)
             {
                 try { RemoveItemDecoration(_itemDecoration); }
-                catch (ObjectDisposedException) { }
+                catch (Exception) { }
             }
 
             try { _itemTouchhelper?.AttachToRecyclerView(null); }
-            catch (ObjectDisposedException) { }
+            catch (Exception) { }
 
             // ステップ2: HeaderView/FooterViewをクリーンアップ
             if (_settingsView?.Root != null)
@@ -124,11 +127,13 @@ public class AiRecyclerView : RecyclerView
             {
                 foreach (var handler in _shouldDisposeHandlers)
                 {
+                    // DisconnectHandler()後にPlatformViewがnullになるため、先に参照を保持する
+                    var pv = handler.PlatformView;
                     handler.DisconnectHandler();
-                    if (handler.PlatformView.Handle != IntPtr.Zero)
+                    if (pv != null && pv.Handle != IntPtr.Zero)
                     {
-                        handler.PlatformView.RemoveFromParent();
-                        handler.PlatformView.Dispose();
+                        pv.RemoveFromParent();
+                        pv.Dispose();
                     }
                 }
             }
@@ -141,11 +146,11 @@ public class AiRecyclerView : RecyclerView
                 _parentPage = null;
             }
 
-            if (_settingsView != null)
+            if (_settingsView?.Root != null)
             {
                 _settingsView.Root.CollectionChanged -= RootCollectionChanged;
-                _settingsView = null;
             }
+            _settingsView = null;
 
             // ステップ5: 切り離し済みのコンポーネントをDispose
             _adapter?.Dispose();
@@ -167,10 +172,15 @@ public class AiRecyclerView : RecyclerView
 
     void DisposeChildView(View view)
     {
-        view.Handler?.DisconnectHandler();
-        var platformView = view.Handler?.PlatformView as AView;
-        platformView?.RemoveFromParent();
-        platformView?.Dispose();
+        // DisconnectHandler()後にview.Handlerがnullになるため、先に参照を保持する
+        var handler = view.Handler as IPlatformViewHandler;
+        var pv = handler?.PlatformView as AView;
+        handler?.DisconnectHandler();
+        if (pv != null && pv.Handle != IntPtr.Zero)
+        {
+            pv.RemoveFromParent();
+            pv.Dispose();
+        }
     }
 
     void ParentPageAppearing(object sender, EventArgs e)
@@ -210,12 +220,14 @@ public class AiRecyclerView : RecyclerView
 
     internal void UpdateSeparatorColor()
     {
+        if (_disposed || _settingsView == null || _divider == null) return;
         _divider.SetTint(_settingsView.SeparatorColor.ToPlatform());
         InvalidateItemDecorations();
     }
 
     internal void UpdateRowHeight()
     {
+        if (_disposed || _settingsView == null) return;
         if (_settingsView.RowHeight == -1)
         {
             _settingsView.RowHeight = 60;
@@ -228,6 +240,7 @@ public class AiRecyclerView : RecyclerView
 
     internal void UpdateScrollToTop()
     {
+        if (_disposed || _settingsView == null || _layoutManager == null) return;
         if (_settingsView.ScrollToTop)
         {
             _layoutManager.ScrollToPosition(0);
@@ -237,6 +250,7 @@ public class AiRecyclerView : RecyclerView
 
     internal void UpdateScrollToBottom()
     {
+        if (_disposed || _settingsView == null || _layoutManager == null) return;
         if (_settingsView.ScrollToBottom)
         {
             if (_adapter != null)
@@ -249,6 +263,7 @@ public class AiRecyclerView : RecyclerView
 
     internal void UpdateBackgroundColor()
     {
+        if (_disposed || _settingsView == null) return;
         if (_settingsView.BackgroundColor.IsNotDefault())
         {
             SetBackgroundColor(_settingsView.BackgroundColor.ToPlatform());


### PR DESCRIPTION
## Summary

- .NET MAUI 9 で `DisconnectPolicy` のデフォルトが `Automatic` に変更され、ページpop時に `DisconnectHandler` → `Dispose()` が自動的に呼ばれるようになった
- 以前はこのパスが実行されなかったため、`Dispose` 内の潜在的NREバグが顕在化した
- `Dispose` を堅牢化し、MAUI 9の自動disconnect対応とする

## Changes

### AiRecyclerView.cs
- `DisconnectHandler()` 後に `PlatformView` がnullになる問題を修正（ステップ3 / DisposeChildView）
- `_settingsView.Root` のnullチェック追加（ステップ4）
- コンストラクタで `_parentPage` のnullガード追加
- ステップ1の catch句を `Exception` に拡張（内部状態破損対応）
- 全 `Update*` メソッドに `_disposed`/nullガード追加

### SettingsViewHandler.Android.cs
- 全Mapperメソッドで `handler.PlatformView?.` に変更

## Root Cause

MAUI 9.0.100以降、`HandlerProperties.DisconnectPolicy` のデフォルトが `Automatic` に変更された。これにより `Page.SendNavigatedFrom` → `DisconnectHandlers` が自動的にページpop時に呼ばれ、今まで実行されなかった `SettingsViewHandler.DisconnectHandler` → `AiRecyclerView.Dispose()` が通るようになった。

## Test plan

- [ ] SettingsViewを含むページのpush/popを繰り返しクラッシュしないことを確認
- [ ] カスタムHeaderView/FooterView付きページでのナビゲーションテスト
- [ ] 高速push/popのストレステスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)