### PR TITLE
Fix NRE in PickerPage.OnDisappearing

### DIFF
--- a/SettingsView/Pages/PickerPage.xaml.cs
+++ b/SettingsView/Pages/PickerPage.xaml.cs
@@ -118,7 +118,15 @@ public partial class PickerPage : ContentPage
     {
         base.OnDisappearing();
 
-        settingsView.Model.RowSelected -= Model_RowSelected;
+        if (settingsView?.Model != null)
+        {
+            settingsView.Model.RowSelected -= Model_RowSelected;
+        }
+
+        if (_pickerCell == null || _selectedCache == null)
+        {
+            return;
+        }
 
         _pickerCell.SelectedItems.Clear();
 


### PR DESCRIPTION
## Summary
- PickerPage.OnDisappearing で MAUI 9 の自動 DisconnectPolicy により NullReferenceException が発生するクラッシュを修正
- `settingsView.Model`、`_pickerCell`、`_selectedCache` への null ガードを追加
- AiRecyclerView.Dispose (3a62c16) と同パターンの防御的修正

## Test plan
- [ ] Android で PickerCell を含む画面を開き、PickerPage に遷移後、戻る操作を繰り返してクラッシュしないことを確認
- [ ] ページ遷移中のバックキー連打・画面回転でクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)