### PR TITLE
Fix NRE in PickerPage.OnDisappearing when SelectedItems is null

### DIFF
--- a/SettingsView/Pages/PickerPage.xaml.cs
+++ b/SettingsView/Pages/PickerPage.xaml.cs
@@ -123,7 +123,7 @@ public partial class PickerPage : ContentPage
             settingsView.Model.RowSelected -= Model_RowSelected;
         }
 
-        if (_pickerCell == null || _selectedCache == null)
+        if (_pickerCell == null || _selectedCache == null || _pickerCell.SelectedItems == null)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- `PickerPage.OnDisappearing` で `_pickerCell.SelectedItems` が null の場合に NullReferenceException が発生するクラッシュを修正
- MAUI 9 の自動 DisconnectPolicy により `SelectedItems` が null 化されるケースに対応

## 原因
コミット c037671 で `_pickerCell` と `_selectedCache` の null チェックは追加されましたが、`_pickerCell.SelectedItems` の null チェックが漏れていました。

## 修正内容
`OnDisappearing` メソッド内で `_pickerCell.SelectedItems.Clear()` を呼び出す前に `_pickerCell.SelectedItems` の null チェックを追加しました。

## クラッシュ情報
- タイトル: AiForms.Settings.Pages.PickerPage.OnDisappearing + 0x22
- 発生件数: 4
- プラットフォーム: Android
- アプリバージョン: 3.0.7

## Test plan
- [ ] Android でタブ切り替え時に PickerPage を含むページが正常に動作することを確認
- [ ] PickerCell の選択が正常に機能することを確認
- [ ] 高速なタブ切り替えでクラッシュが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)